### PR TITLE
DAWG-121: Create shared acceptance test github action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,14 +1,27 @@
-name: 'Hello World'
-description: 'Greet someone'
-inputs:
-  who-to-greet:  # id of input
-    description: 'Who to greet'
-    required: true
-    default: 'World'
+name: 'Run acceptance tests'
+description: 'Run acceptance tests for a Node-based package'
 runs:
   using: "composite"
   steps:
-    - run: echo Hello ${{ inputs.who-to-greet }}.
+    - uses: actions/cache@v3
+      id: restore-commit
+      with:
+        path: ./*
+        key: ${{ github.sha }}
+    - name: Checkout
+      if: steps.restore-commit.outputs.cache-hit != 'true'
+      uses: actions/checkout@v3.0.2
+    - uses: actions/cache@v3
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+    - name: Run Acceptance Tests
       shell: bash
-    - run: echo "${{ github.action_path }}" >> $GITHUB_PATH
-      shell: bash          
+      run: npm run test:acceptance:ci --if-present
+    - name: Upload Test Coverage
+      uses: actions/upload-artifact@v3.1.0
+      with:
+        name: Acceptance Test Coverage
+        path: coverage


### PR DESCRIPTION
## Dependencies of PR

None

## Description of Changes

This adds a new shared github action for running acceptance tests. This action can then be used across all our Node-based repositories similar to other shared actions we've done.

## Testing

- Verify the usage of this GH action in the CCT PR works as expected: https://github.com/OpenSesame/course-authoring-ui-authoring/pull/624

[Jira Task Link](https://opensesame.atlassian.net/browse/DAWG-121)
